### PR TITLE
Add version flag to display the application version

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ Flags:
                               Default value is "false".
 
                               Example: -c|--use-cache (provide a flag)
+
+  -v, --version              Print the application version and exit.
 ```
 
 ## ⚠️ Known Issues

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -33,6 +33,7 @@ var (
 	useCache        bool
 	clearCache      bool
 	simpleCS        bool
+	versionFlag     bool
 	settings        *config.Settings
 
 	tree *structure.Tree
@@ -202,6 +203,17 @@ Example: --clear-cache (provide a flag)
 Example: --simple-color (provide a flag)
 `,
 	)
+
+	appCmd.PersistentFlags().BoolVarP(
+		&versionFlag,
+		"version",
+		"v",
+		false,
+		`Print the application version and exit.
+	
+Example: -v|--version (provide a flag)
+`,
+	)
 }
 
 func Execute() {
@@ -254,6 +266,13 @@ func initConfig() (*config.Settings, error) {
 }
 
 func runApp(_ *cobra.Command, _ []string) error {
+	if versionFlag {
+		if _, err := os.Stdout.WriteString(render.Version + "\n"); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	var (
 		err   error
 		style *render.Style

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -270,6 +270,7 @@ func runApp(_ *cobra.Command, _ []string) error {
 		if _, err := os.Stdout.WriteString(render.Version + "\n"); err != nil {
 			return err
 		}
+
 		return nil
 	}
 

--- a/man/noxdir.1
+++ b/man/noxdir.1
@@ -90,6 +90,10 @@ Use a simplified color schema without emojis and glyphs.
 Example: \fB--simple-color\fR
 
 .TP
+.BR -v ", " --version
+Print the application version and exit.
+
+.TP
 .BR -h ", " --help
 Show help and usage information.
 


### PR DESCRIPTION
Introduce `-v, --version` flag to print the application version. Updated `man` page and `README.md` accordingly.