### PR TITLE
Additional color customization options

### DIFF
--- a/default-color-schema.json
+++ b/default-color-schema.json
@@ -47,6 +47,15 @@
   "activeButtonText": "#FFFDF5",
   "activeButtonBackground": "#FF8531",
   "filterText": "#EBBD34",
+  "diffAddedMarker": "#06923E",
+  "diffRemovedMarker": "#FF303E",
+  "usageThresholdText": "#dc2f02",
+  "sizeUnit": {
+    "GB": "#f48c06",
+    "TB": "#dc2f02",
+    "PB": "#9d0208",
+    "EB": "#6a040f"
+  },
   "statusBarBorder": true,
   "scanProgressBar": {
     "colorProfile": 0,

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -86,8 +86,8 @@ type NameFilter struct {
 	enabled bool
 }
 
-func NewNameFilter(placeholder string) *NameFilter {
-	textStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#ebbd34"))
+func NewNameFilter(placeholder string, textColor string) *NameFilter {
+	textStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(textColor))
 	ti := textinput.New()
 
 	ti.Placeholder = placeholder

--- a/render/color_schema.go
+++ b/render/color_schema.go
@@ -45,6 +45,13 @@ type StatusBarColors struct {
 	Dirs      DirsStatusBarColors   `json:"dirs"`
 }
 
+type SizeUnitColors struct {
+	GB string `json:"gB"`
+	TB string `json:"tB"`
+	PB string `json:"pB"`
+	EB string `json:"eB"`
+}
+
 // The ColorSchema schema contains color values for most UI elements, such as
 // text and border colors, element backgrounds, etc. The Style component uses
 // the ColorSchema instance during rendering elements. Each color value must be
@@ -53,26 +60,30 @@ type StatusBarColors struct {
 // DefaultColorSchema always used as a base schema and all customizations are
 // applied over it.
 type ColorSchema struct {
-	StatusBar         StatusBarColors `json:"statusBar"`
-	ChartColors       ChartColors     `json:"chart"`
-	CellText          string          `json:"cellText"`
-	TableHeaderBorder string          `json:"tableHeaderBorder"`
-	SelectedRowText   string          `json:"selectedRowText"`
-	SelectedRowBG     string          `json:"selectedRowBackground"`
-	MarkedRowText     string          `json:"markedRowText"`
-	MarkedRowBG       string          `json:"markedRowBackground"`
-	TopFilesText      string          `json:"topFilesText"`
-	HelpText          string          `json:"helpText"`
-	BindingText       string          `json:"bindingText"`
-	DialogBoxBorder   string          `json:"dialogBoxBorder"`
-	ConfirmButtonText string          `json:"confirmButtonText"`
-	ConfirmButtonBG   string          `json:"confirmButtonBackground"`
-	ActiveButtonText  string          `json:"activeButtonText"`
-	ActiveButtonBG    string          `json:"activeButtonBackground"`
-	FilterText        string          `json:"filterText"`
-	ScanProgressBar   PG              `json:"scanProgressBar"`
-	UsageProgressBar  PG              `json:"usageProgressBar"`
-	StatusBarBorder   bool            `json:"statusBarBorder"`
+	StatusBar          StatusBarColors `json:"statusBar"`
+	ChartColors        ChartColors     `json:"chart"`
+	CellText           string          `json:"cellText"`
+	TableHeaderBorder  string          `json:"tableHeaderBorder"`
+	SelectedRowText    string          `json:"selectedRowText"`
+	SelectedRowBG      string          `json:"selectedRowBackground"`
+	MarkedRowText      string          `json:"markedRowText"`
+	MarkedRowBG        string          `json:"markedRowBackground"`
+	TopFilesText       string          `json:"topFilesText"`
+	HelpText           string          `json:"helpText"`
+	BindingText        string          `json:"bindingText"`
+	DialogBoxBorder    string          `json:"dialogBoxBorder"`
+	ConfirmButtonText  string          `json:"confirmButtonText"`
+	ConfirmButtonBG    string          `json:"confirmButtonBackground"`
+	ActiveButtonText   string          `json:"activeButtonText"`
+	ActiveButtonBG     string          `json:"activeButtonBackground"`
+	FilterText         string          `json:"filterText"`
+	DiffAddedMarker    string          `json:"diffAddedText"`
+	DiffRemovedMarker  string          `json:"diffRemovedText"`
+	UsageThresholdText string          `json:"usageThresholdText"`
+	SizeUnit           SizeUnitColors  `json:"sizeUnit"`
+	ScanProgressBar    PG              `json:"scanProgressBar"`
+	UsageProgressBar   PG              `json:"usageProgressBar"`
+	StatusBarBorder    bool            `json:"statusBarBorder"`
 }
 
 // DecodeColorSchema reads the color schema from the file by the provided
@@ -141,22 +152,31 @@ func DefaultColorSchema() ColorSchema {
 			Sector8:        "#ff85a1",
 			Sector9:        "#b5838d",
 		},
-		CellText:          "",
-		TableHeaderBorder: "240",
-		SelectedRowText:   "#262626",
-		SelectedRowBG:     "#EBBD34",
-		MarkedRowText:     "#262626",
-		MarkedRowBG:       "#eae2b7",
-		TopFilesText:      "#EBBD34",
-		HelpText:          "#696868",
-		BindingText:       "#FFBF69",
-		DialogBoxBorder:   "240",
-		ConfirmButtonText: "#FFFDF5",
-		ConfirmButtonBG:   "#353533",
-		ActiveButtonText:  "#FFFDF5",
-		ActiveButtonBG:    "#FF8531",
-		FilterText:        "#EBBD34",
-		StatusBarBorder:   true,
+		CellText:           "",
+		TableHeaderBorder:  "240",
+		SelectedRowText:    "#262626",
+		SelectedRowBG:      "#EBBD34",
+		MarkedRowText:      "#262626",
+		MarkedRowBG:        "#eae2b7",
+		TopFilesText:       "#EBBD34",
+		HelpText:           "#696868",
+		BindingText:        "#FFBF69",
+		DialogBoxBorder:    "240",
+		ConfirmButtonText:  "#FFFDF5",
+		ConfirmButtonBG:    "#353533",
+		ActiveButtonText:   "#FFFDF5",
+		ActiveButtonBG:     "#FF8531",
+		FilterText:         "#EBBD34",
+		DiffAddedMarker:    "#06923E",
+		DiffRemovedMarker:  "#FF303E",
+		UsageThresholdText: "#dc2f02",
+		SizeUnit: SizeUnitColors{
+			GB: "#f48c06",
+			TB: "#dc2f02",
+			PB: "#9d0208",
+			EB: "#6a040f",
+		},
+		StatusBarBorder: true,
 	}
 }
 

--- a/render/diff_model.go
+++ b/render/diff_model.go
@@ -175,11 +175,11 @@ func (dm *DiffModel) updateTableData() {
 	}
 
 	removedIcon := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#FF303E")).
+		Foreground(lipgloss.Color(style.CS().DiffAddedMarker)).
 		Render("---  ")
 
 	addedIcon := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#06923E")).
+		Foreground(lipgloss.Color(style.CS().DiffRemovedMarker)).
 		Render("+++  ")
 
 	iconWidth := 5

--- a/render/dir_model.go
+++ b/render/dir_model.go
@@ -97,7 +97,7 @@ type DirModel struct {
 func NewDirModel(nav *Navigation, filters ...filter.EntryFilter) *DirModel {
 	defaultFilters := append(
 		[]filter.EntryFilter{
-			filter.NewNameFilter("Filter..."),
+			filter.NewNameFilter("Filter...", style.CS().FilterText),
 			&filter.DirsFilter{},
 			&filter.FilesFilter{},
 		},

--- a/render/fmt.go
+++ b/render/fmt.go
@@ -14,13 +14,6 @@ var sizeUnits = []string{
 	"B", "KB", "MB", "GB", "TB", "PB", "EB",
 }
 
-var sizeUnitsSeverity = map[string]string{
-	"GB": "#f48c06",
-	"TB": "#dc2f02",
-	"PB": "#9d0208",
-	"EB": "#6a040f",
-}
-
 type numeric interface {
 	int | uint | uint64 | int64 | int32 | float64 | float32
 }
@@ -38,20 +31,17 @@ func FmtSize[T numeric](bytesSize T, width int) string {
 
 func FmtSizeColor[T numeric](bytesSize T, width, fullWidth int) string {
 	size, suffix := fmtSize(bytesSize)
-	padding, severity := 1, sizeUnitsSeverity[suffix]
+	padding, sizeUnitStyle := 1, style.SizeUnit(suffix)
 
 	if width > 0 {
 		padding = max(width-len(size)-len(suffix), padding)
 	}
 
-	if len(severity) > 0 {
-		suffix = lipgloss.NewStyle().Foreground(
-			lipgloss.Color(severity),
-		).Render(suffix + strings.Repeat(" ", fullWidth))
-	}
-
 	return lipgloss.JoinHorizontal(
-		lipgloss.Left, size, strings.Repeat(" ", padding), suffix,
+		lipgloss.Left,
+		size,
+		strings.Repeat(" ", padding),
+		sizeUnitStyle.Render(suffix+strings.Repeat(" ", fullWidth)),
 	)
 }
 
@@ -100,7 +90,7 @@ func FmtUsage(usage, threshold float64, fullWidth int) string {
 	s := lipgloss.NewStyle()
 
 	if usagePercent > threshold {
-		s = s.Foreground(lipgloss.Color("#dc2f02"))
+		s = s.Foreground(lipgloss.Color(style.CS().UsageThresholdText))
 	}
 
 	usageStr := strconv.FormatFloat(usagePercent, 'f', 2, 64)

--- a/render/style.go
+++ b/render/style.go
@@ -1,6 +1,7 @@
 package render
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/charmbracelet/lipgloss"
@@ -235,4 +236,24 @@ func (s *Style) ChartColors() []lipgloss.Color {
 		lipgloss.Color(s.cs.ChartColors.Sector8),
 		lipgloss.Color(s.cs.ChartColors.Sector9),
 	}
+}
+
+func (s *Style) SizeUnit(unit string) *lipgloss.Style {
+	ck := fmt.Sprintf("sizeUnit-%s", unit)
+	cv, ok := s.cache[ck]
+	if !ok {
+		sizeUnitColorsMap := map[string]string{
+			"GB": s.cs.SizeUnit.GB,
+			"TB": s.cs.SizeUnit.TB,
+			"PB": s.cs.SizeUnit.PB,
+			"EB": s.cs.SizeUnit.EB,
+		}
+		color := sizeUnitColorsMap[unit]
+		cs := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
+		s.cache[ck] = &cs
+
+		return &cs
+	}
+
+	return cv
 }


### PR DESCRIPTION
Hi, I'm a maintainer of the [catppuccin](https://github.com/catppuccin/catppuccin) palette and I'm in the process of creating a color scheme for noxdir. I noticed a few hard coded hex values in the code base that make it challenging to create a user friendly UI. For instance the color choices for size unit results in poor readability when using a red highlight color. Thus I added a few extra config options to allow for more customization.

Before:
<img width="812" height="415" alt="image" src="https://github.com/user-attachments/assets/5a1843cb-b475-4667-b26b-2f91bc44318f" />
After:
<img width="812" height="415" alt="image" src="https://github.com/user-attachments/assets/793a41a4-76b0-4ce3-9f5a-bc1f253f0c8e" />

Before:
<img width="469" height="156" alt="image" src="https://github.com/user-attachments/assets/87f2e9c1-5cb6-454b-bb8b-5fd135f92e6e" />
After:
<img width="469" height="156" alt="image" src="https://github.com/user-attachments/assets/1f00122f-081a-4f3f-88e8-dd9296988d2d" />
