### PR TITLE
Removed architecture specific syscall

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         go: [ stable ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Fixes #108

`SysNewFstatat` is an architecture specific value. Using this number in `Syscall6` causes different behavior between x86 and aarch64 systems. It is best to use `unix.Fstatat` instead of creating a custom `fstatat` function.